### PR TITLE
Fix byte overflow in rdb.go

### DIFF
--- a/rdb.go
+++ b/rdb.go
@@ -285,9 +285,9 @@ func (filter *RDBFilter) readString() (string, error) {
 		if encoding == 0 {
 			num = uint32(data[0])
 		} else if encoding == 1 {
-			num = uint32(data[0] | (data[1] << 8))
+			num = uint32(data[0]) | (uint32(data[1]) << 8)
 		} else if encoding == 2 {
-			num = uint32(data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24))
+			num = uint32(data[0]) | (uint32(data[1]) << 8) | (uint32(data[2]) << 16) | (uint32(data[3]) << 24)
 		}
 
 		result = fmt.Sprintf("%d", num)


### PR DESCRIPTION
Hi
I found a possible overflow in rdb.go 
https://github.com/smira/redis-resharding-proxy/blob/master/rdb.go#L288-L290 

A patch to fix it
